### PR TITLE
Dedup pip dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,3 +91,13 @@ http_file(
              "96686bc6abafacb579334f8c61be2f025f1be161d266893d17b47afd7685/" +
              "google_cloud_spanner-1.9.0-py2.py3-none-any.whl")],
 )
+
+http_file(
+    name = "pytest_flask_0_14_0_whl",
+    downloaded_file_path = "pytest_flask-0.14.0-py2.py3-none-any.whl",
+    sha256 = "e9b120d23f73e0495d8fa1bc3b580b18cc9f98b8d6808bc45fdbcbab7d718242",
+    # From https://pypi.org/simple/pytest-flask/
+    urls = [("https://files.pythonhosted.org/packages/52/a8/" +
+             "3fab52af3688311921205439e3e543b2b1fcce0e3c8acd2cad8061ecfe4f/" +
+             "pytest_flask-0.14.0-py2.py3-none-any.whl")]
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,5 +99,5 @@ http_file(
     # From https://pypi.org/simple/pytest-flask/
     urls = [("https://files.pythonhosted.org/packages/52/a8/" +
              "3fab52af3688311921205439e3e543b2b1fcce0e3c8acd2cad8061ecfe4f/" +
-             "pytest_flask-0.14.0-py2.py3-none-any.whl")]
+             "pytest_flask-0.14.0-py2.py3-none-any.whl")],
 )

--- a/src/whl.py
+++ b/src/whl.py
@@ -105,7 +105,7 @@ def dependencies(pkg, extra=None):
     :rtype: list
 
     """
-    ret = []
+    ret = set()
     for dist in pkg.requires_dist:
         requirement = pkg_resources.Requirement.parse(dist)
         if extra:
@@ -119,14 +119,14 @@ def dependencies(pkg, extra=None):
                 continue
 
         if requirement.extras:
-            ret.extend(
+            ret = ret | set([
                 "{}[{}]".format(requirement.name, dist_extra)
                 for dist_extra in requirement.extras
-            )
+            ])
         else:
-            ret.append(requirement.name)
+            ret.add(requirement.name)
 
-    return ret
+    return list(ret)
 
 
 def _cleanup(directory, pattern):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,6 +11,7 @@ py_test(
         "@google_cloud_language_whl//file",
         "@grpc_whl//file",
         "@mock_whl//file",
+        "@pytest_flask_0_14_0_whl//file",
     ],
     main = "test_whl.py",
     python_version = "PY3",

--- a/tests/test_whl.py
+++ b/tests/test_whl.py
@@ -115,7 +115,7 @@ class WheelTest(unittest.TestCase):
             'Flask',
             'Werkzeug',
         ]
-        self.assertEqual(set(whl.dependencies(td)), set(expected_deps))
+        self.assertEqual(whl.dependencies(td), expected_deps)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_whl.py
+++ b/tests/test_whl.py
@@ -115,7 +115,8 @@ class WheelTest(unittest.TestCase):
             'Flask',
             'Werkzeug',
         ]
-        self.assertEqual(whl.dependencies(td), expected_deps)
+        self.assertEqual(len(whl.dependencies(td)), len(expected_deps))
+        self.assertEqual(set(whl.dependencies(td)), set(expected_deps))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_whl.py
+++ b/tests/test_whl.py
@@ -102,6 +102,20 @@ class WheelTest(unittest.TestCase):
         ]
         self.assertEqual(set(whl.dependencies(td)), set(expected_deps))
 
+    @patch("platform.python_version", return_value="2.7.13")
+    def test_pytest_flask_whl(self, *args):
+        td = pkginfo.Wheel(
+            TestData(
+                "pytest_flask_0_14_0_whl/file/"
+                + "pytest_flask-0.14.0-py2.py3-none-any.whl"
+            )
+        )
+        expected_deps = [
+            'pytest',
+            'Flask',
+            'Werkzeug',
+        ]
+        self.assertEqual(set(whl.dependencies(td)), set(expected_deps))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR tries to address https://github.com/ali5h/rules_pip/issues/22.

The underlying issue is that wheel allows the existence of duplicate dependency specification so long as there's different version constraints. For example,

```
Requires-Dist: pytest (>=3.6)
Requires-Dist: Flask
Requires-Dist: Werkzeug (>=0.7)
Requires-Dist: pytest
```

This is a valid specification.

