### PR TITLE
piptool: add all_requirements constant to output

### DIFF
--- a/src/piptool.py
+++ b/src/piptool.py
@@ -172,6 +172,8 @@ _requirements = {{
   {mappings}
 }}
 
+all_requirements = _requirements.values()
+
 def requirement(name, target=None):
   name_key = name.lower()
   if name_key not in _requirements:


### PR DESCRIPTION
The bazelbuild `rules_python` exposes an [`all_requirements` variable](https://github.com/bazelbuild/rules_python/blob/a0fbf98d4e3a232144df4d0d80b577c7a693b570/packaging/piptool.py#L236) which is pretty useful. It's usage is [documented here](https://github.com/bazelbuild/rules_python/blob/748aa53d7701e71101dfd15d800e100f6ff8e5d1/python/pip.bzl#L107), and is useful for when we already have requirements grouped into different files.

Let me know what your thoughts are, if it needs more documentation or something.