### PR TITLE
pytest: allow customising test runner args

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -146,7 +146,16 @@ If the label is specified it will overwrite the python_interpreter attribute.
     implementation = _whl_impl,
 )
 
-def py_pytest_test(name, **kwargs):
+def py_pytest_test(
+        name,
+        # This argument exists for back-compatibility with earlier versions
+        pytest_args = [
+            "--ignore=external",
+            ".",
+            "-p",
+            "no:cacheprovider",
+        ],
+        **kwargs):
     """A macro that runs pytest tests by using a test runner
     :param name: rule name
     :param kwargs: are passed to py_test, with srcs and deps attrs modified
@@ -157,6 +166,7 @@ def py_pytest_test(name, **kwargs):
 
     deps = kwargs.pop("deps", []) + ["@com_github_ali5h_rules_pip//src:pytest_helper"]
     srcs = kwargs.pop("srcs", []) + ["@com_github_ali5h_rules_pip//src:pytest_helper"]
+    args = kwargs.pop("args", []) + pytest_args
 
     # failsafe, pytest won't work otw.
     for src in srcs:
@@ -169,5 +179,6 @@ def py_pytest_test(name, **kwargs):
         srcs = srcs,
         main = "pytest_helper.py",
         deps = deps,
+        args = args,
         **kwargs
     )

--- a/src/pytest_helper.py
+++ b/src/pytest_helper.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def run(argv=None):
-    args = sys.argv + ["--ignore=external", ".", "-p", "no:cacheprovider"]
+    args = sys.argv
     return pytest.main(args)
 
 


### PR DESCRIPTION
I'd like to customise the arguments that are passed to `pytest` by the `py_pytest_test` rule. My usecase is I only want to test files in a specific directory, and currently the `"."` (test this directory) argument is hardcoded.

This PR moves the default arguments from `pytest_helper.py` into the `defs.bzl` definition, so they can be overridden. For backwards compatibility, they have been named as a new argument, `pytest_args`, rather than just `args`.

These can then be adjusted like so:
```bzl
py_pytest_test(
    ...
    args = ["$(locations :lib_test)"],
    pytest_args = [
        "-vv",
        "--ignore=external",
        "-p",
        "no:cacheprovider",
    ],
)
```