### PR TITLE
Generate BUILD file with aliases for wheels packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,33 @@ pip_import(
 load("@pip_deps//:requirements.bzl", "pip_install")
 pip_install([<optional pip install args])
 ```
+
+## Target dependencies
+
+To use pip packages you can
+
+* add dependencies via `requirement` macro as
+
+```python
+load("@pip_deps//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "main",
+    srcs = ["main.py"],
+    deps = [
+        requirement("pip-module")
+    ]
+)
+```
+
+* use package aliases as
+
+```python
+py_binary(
+    name = "main",
+    srcs = ["main.py"],
+    deps = [
+        "@pip_deps//:pip-module"
+    ]
+)
+```

--- a/examples/tests/BUILD
+++ b/examples/tests/BUILD
@@ -17,7 +17,8 @@ py_pytest_test(
         # to test metadata parsing
         requirement("python-dateutil"),
         requirement("xgboost"),
-        requirement("numpy"),
+        # to test package alias
+        "@piptool_deps_tests_3//:numpy",
     ],
 )
 


### PR DESCRIPTION
Add convenience aliases to a `BUILD` file that is a sibling file to `args.output` one. Aliases allow to avoid loading `@external_pip//:requirements.bzl` file and use `@external_pip//:pip` targets directly. The alias target names are taken from the `args.input` as-is without lower-casing and have public visibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ali5h/rules_pip/36)
<!-- Reviewable:end -->
