### PR TITLE
add quiet mode to whl install

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -63,11 +63,12 @@ load(
 )
 
 # pip_install acts like pip install command and can accept arguments
-pip_install([
+pip_install(pip_args = [
     "--only-binary",
     ":all",
-    "--platform",
-    "manylinux1_x86_64",
+    # more pip install flags
+    # "--platform",
+    # "manylinux1_x86_64",
 ])
 
 load("@com_github_ali5h_rules_pip//third_party/cpython:configure.bzl", "python_configure")

--- a/src/whl.py
+++ b/src/whl.py
@@ -54,13 +54,13 @@ def install_package(pkg, directory, pip_args):
     """Downloads wheel for a package. Assumes python binary provided has
     pip and wheel package installed.
 
-    :param pkg: package name
-    :param directory: destination directory to download the wheel file in
-    :param python: python binary path used to run pip command
-    :param pip_args: extra pip args sent to pip
-    :returns: path to the wheel file
-    :rtype: str
-
+    Args:
+        pkg: package name
+        directory: destination directory to download the wheel file in
+        python: python binary path used to run pip command
+        pip_args: extra pip args sent to pip
+    Returns:
+        str: path to the wheel file
     """
     pip_args = [
         "--isolated",
@@ -102,13 +102,13 @@ def install_package(pkg, directory, pip_args):
 
 
 def dependencies(pkg, extra=None):
-    """find dependencies of a wheel.
+    """Find dependencies of a wheel.
 
-    :param whl_path: path to wheel
-    :param extra: find additional dependencies for the extra instead
-    :returns: list of dependencies
-    :rtype: list
-
+    Args:
+        whl_path: path to wheel
+        extra: find additional dependencies for the extra instead
+    Returns:
+        list: list of dependencies
     """
     ret = set()
     for dist in pkg.requires_dist:
@@ -143,10 +143,10 @@ def _cleanup(directory, pattern):
 def _get_numpy_headers(directory):
     """Generate cc_library rule for numpy headers.
 
-    :param directory: path to numpy package installation root
-    :returns: a cc_library rule
-    :rtype: str
-
+    Args:
+        directory: path to numpy package installation root
+    Returns:
+        str: a cc_library rule
     """
     sys.path.insert(0, directory)
     import numpy


### PR DESCRIPTION
By setting `quiet = True` in `pip_import`, install logs will be suppressed. This is the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ali5h/rules_pip/45)
<!-- Reviewable:end -->
