### PR TITLE
don't use backslashes in Python interpreter path on Windows

### DIFF
--- a/src/piptool.py
+++ b/src/piptool.py
@@ -110,7 +110,7 @@ def whl_library(
         name=name,
         repo_name=repo_name,
         pip_repo_name=pip_repo_name,
-        python_interpreter=python_interpreter,
+        python_interpreter=python_interpreter.replace("\\", "/"),
         extras=",".join(['"%s"' % extra for extra in extras]),
         timeout=timeout,
         quiet=quiet,

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -155,10 +155,16 @@ def main():
         required=True,
     )
     parser.add_argument(
-        "--timeout", help="Timeout used for pip actions.", type=int, required=True,
+        "--timeout",
+        help="Timeout used for pip actions.",
+        type=int,
+        required=True,
     )
     parser.add_argument(
-        "--quiet", help="Make pip install action quiet.", type=bool, required=True,
+        "--quiet",
+        help="Make pip install action quiet.",
+        type=bool,
+        required=True,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
When passing in a runtime to pip_import() that is symlinked to a
Windows path, eg:

        python_runtime = "@python//:python",

which is symlinked to c:\python\python.exe

then the backslash-containing path is included verbatim in
the generated repositories.bzl file. When Bazel tries to read
the file, it complains about unrecognized control characters.
Converting the backslashes to forward slashes fixes the error,
and allows the build to proceed.