### PR TITLE
defer requirement() failure until build time

### DIFF
--- a/src/piptool.py
+++ b/src/piptool.py
@@ -211,7 +211,7 @@ all_requirements = _requirements.values()
 def requirement(name, target=None):
   name_key = name.lower()
   if name_key not in _requirements:
-    fail("Could not find pip-provided dependency: '%s'" % name)
+    return name_key + "_not_found_in_requirements"
   req = _requirements[name_key]
   if target != None:
     pkg, _, _ = req.partition("//")


### PR DESCRIPTION
I'd like to use select() to conditionally include dependencies depending
on platform, eg a py_binary with

deps = select({
        "@bazel_tools//src/conditions:host_windows": [
            requirement("psutil"),
            requirement("pywin32"),
        ],
        "//conditions:default": [],
    })

Currently this doesn't work, as requirement() is executed on all
platforms. This patch changes requirement() to return an invalid key
instead of using fail(), which will allow such usages of select().
If the user specifies a requirement that was not listed in the
requirements file, they should still get an error at build time
which identifies the missing package.