### PR TITLE
expose bundled binaries in library rule

### DIFF
--- a/src/whl.py
+++ b/src/whl.py
@@ -235,7 +235,6 @@ py_library(
         "**/* *",
         "BUILD",
         "WORKSPACE",
-        "bin/*",
         "__pycache__",
     ]),
     # This makes this directory a top-level in the python import


### PR DESCRIPTION
This matches the behaviour of rules_python, and allows access
to a binary file bundled in a wheel when the library is included
as a dependency.

https://github.com/bazelbuild/rules_python/blob/aa27a3fe7e1a6c73028effe1c78e87d2e7fab641/packaging/whl.py#L188