### PR TITLE
Expose distinfo files

### DIFF
--- a/src/whl.py
+++ b/src/whl.py
@@ -245,6 +245,12 @@ py_library(
         {dependencies}
     ],
 )
+
+filegroup(
+    name = "distinfo",
+    srcs = glob(["*.dist-info/**"]),
+)
+
 {extras}""".format(
         requirements=args.requirements,
         dependencies=",".join(['requirement("%s")' % d for d in dependencies(pkg)]),


### PR DESCRIPTION
This allows exposing things like `entry_points.txt`, which distutils uses to automatically find new commands (such as bdist_wheel)