### PR TITLE
Allow replacing pip dependencies with targets

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -54,8 +54,8 @@ def _pip_import_impl(repository_ctx):
         str(repository_ctx.attr.quiet),
     ]
 
-    for label, pipdep in repository_ctx.attr.replace_requirements.items():
-        args += ["--replace_requirement=%s=%s" % (label, pipdep)]
+    for label, pipdep in repository_ctx.attr.overrides.items():
+        args += ["--overrides=%s=%s" % (pipdep, label)]
 
     result = _execute(repository_ctx, args, quiet = repository_ctx.attr.quiet)
     if result.return_code:
@@ -82,13 +82,13 @@ The prefix for the bazel repository name.
         "compile": attr.bool(
             default = False,
         ),
-        "replace_requirements": attr.label_keyed_string_dict(doc = """
+        "overrides": attr.label_keyed_string_dict(doc = """
 Specify to replace certain pip dependencies with bazel dependencies.
 
 pip_import(
     name = "pipdeps",
     ...
-    replace_requirements = {
+    overrides = {
         "@com_google_protobuf//:protobuf_python": "protobuf",
     },
 )
@@ -146,8 +146,8 @@ def _whl_impl(repository_ctx):
             "--extras=%s" % extra
             for extra in repository_ctx.attr.extras
         ]
-    for label, pipdep in repository_ctx.attr.replace_requirements.items():
-        args += ["--replace_requirement=%s=%s" % (label, pipdep)]
+    for label, pipdep in repository_ctx.attr.overrides.items():
+        args += ["--overrides=%s=%s" % (label, pipdep)]
 
     args += pip_args
 
@@ -170,7 +170,7 @@ If the label is specified it will overwrite the python_interpreter attribute.
 """),
         "pip_args": attr.string_list(default = []),
         "timeout": attr.int(default = 1200, doc = "Timeout for pip actions"),
-        "replace_requirements": attr.label_keyed_string_dict(),
+        "overrides": attr.label_keyed_string_dict(),
         "_script": attr.label(
             executable = True,
             default = Label("@com_github_ali5h_rules_pip//src:whl.py"),

--- a/defs.bzl
+++ b/defs.bzl
@@ -55,7 +55,7 @@ def _pip_import_impl(repository_ctx):
     ]
 
     for label, pipdep in repository_ctx.attr.overrides.items():
-        args += ["--overrides=%s=%s" % (pipdep, label)]
+        args += ["--override=%s=%s" % (pipdep, label)]
 
     result = _execute(repository_ctx, args, quiet = repository_ctx.attr.quiet)
     if result.return_code:
@@ -147,7 +147,7 @@ def _whl_impl(repository_ctx):
             for extra in repository_ctx.attr.extras
         ]
     for label, pipdep in repository_ctx.attr.overrides.items():
-        args += ["--overrides=%s=%s" % (label, pipdep)]
+        args += ["--override=%s=%s" % (label, pipdep)]
 
     args += pip_args
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -82,7 +82,19 @@ The prefix for the bazel repository name.
         "compile": attr.bool(
             default = False,
         ),
-        "replace_requirements": attr.label_keyed_string_dict(),
+        "replace_requirements": attr.label_keyed_string_dict(doc = """
+Specify to replace certain pip dependencies with bazel dependencies.
+
+pip_import(
+    name = "pipdeps",
+    ...
+    replace_requirements = {
+        "@com_google_protobuf//:protobuf_python": "protobuf",
+    },
+)
+
+This replaces "protobuf" with the bazel version even for indirect dependencies on it.
+"""),
         "timeout": attr.int(default = 1200, doc = "Timeout for pip actions"),
         "_script": attr.label(
             executable = True,

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -69,10 +69,10 @@ pip_import(
     name = "piptool_deps_tests_3",
     timeout = 1200,
     compile = False,
-    python_interpreter = "python3.8",
     overrides = {
         "@pytz//:pkg": "pytz",
     },
+    python_interpreter = "python3.8",
     requirements = "//tests:requirements.txt",
 )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -70,7 +70,7 @@ pip_import(
     timeout = 1200,
     compile = False,
     python_interpreter = "python3.8",
-    replace_requirements = {
+    overrides = {
         "@pytz//:pkg": "pytz",
     },
     requirements = "//tests:requirements.txt",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -47,6 +47,22 @@ local_repository(
     path = "..",
 )
 
+http_archive(
+    name = "pytz",
+    build_file_content = """
+py_library(
+    name = "pkg",
+    srcs = glob(["*.py"]),
+    data = glob(["zoneinfo/*"]),
+    visibility = ["//visibility:public"],
+    imports = ["."],
+)
+""",
+    sha256 = "acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326",
+    strip_prefix = "pytz-2021.3/pytz",
+    urls = ["https://files.pythonhosted.org/packages/e3/8e/1cde9d002f48a940b9d9d38820aaf444b229450c0854bdf15305ce4a3d1a/pytz-2021.3.tar.gz"],
+)
+
 load("@com_github_ali5h_rules_pip//:defs.bzl", "pip_import")
 
 pip_import(
@@ -55,6 +71,9 @@ pip_import(
     compile = False,
     python_interpreter = "python3.8",
     requirements = "//tests:requirements.txt",
+    replace_requirements = {
+        "@pytz//:pkg": "pytz",
+    },
 )
 
 load(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -70,10 +70,10 @@ pip_import(
     timeout = 1200,
     compile = False,
     python_interpreter = "python3.8",
-    requirements = "//tests:requirements.txt",
     replace_requirements = {
         "@pytz//:pkg": "pytz",
     },
+    requirements = "//tests:requirements.txt",
 )
 
 load(

--- a/examples/tests/test_import.py
+++ b/examples/tests/test_import.py
@@ -13,3 +13,6 @@ def test_xgboost():
 def test_numpy():
     import numpy
     import tests._test
+
+def test_pytz():
+    import pytz

--- a/examples/tests/test_import.py
+++ b/examples/tests/test_import.py
@@ -14,5 +14,6 @@ def test_numpy():
     import numpy
     import tests._test
 
+
 def test_pytz():
     import pytz

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -82,7 +82,7 @@ def whl_library(
     python_interpreter,
     timeout,
     quiet,
-    replace_requirements,
+    overrides,
 ):
     """Generate whl_library snippets for a package and its extras.
 
@@ -94,7 +94,7 @@ def whl_library(
         python_interpreter:
         timeout: timeout for pip actions
         quiet: makes command run in quiet mode
-        replace_requirements: map from requirement to replacement label
+        overrides: map from requirement to replacement label
     Returns:
       str: whl_library rule definition
     """
@@ -110,7 +110,7 @@ def whl_library(
         pip_args = pip_args,
         timeout = {timeout},
         quiet = {quiet},
-        replace_requirements = {replace_requirements},
+        overrides = {overrides},
     )""".format(
         name=name,
         repo_name=repo_name,
@@ -119,7 +119,7 @@ def whl_library(
         extras=",".join(['"%s"' % extra for extra in extras]),
         timeout=timeout,
         quiet=quiet,
-        replace_requirements=replace_requirements,
+        overrides=overrides,
     )
 
 
@@ -173,16 +173,16 @@ def main():
         required=True,
     )
     parser.add_argument(
-        "--replace_requirement",
+        "--override",
         action="append",
         default=[],
         help="Specified to replace pip dependencies with bazel targets. Example: "
-        + "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
+        + "--override=protobuf=@com_google_protobuf//:protobuf_python",
     )
     args = parser.parse_args()
 
     reqs = sorted(get_requirements(args.input), key=as_tuple)
-    replace_requirements = dict(rep.split("=") for rep in args.replace_requirement)
+    overrides = dict(rep.split("=") for rep in args.override)
     python_version = "%d%d" % (sys.version_info[0], sys.version_info[1])
     whl_targets = OrderedDict()
     whl_libraries = []
@@ -203,7 +203,7 @@ def main():
                 sys.executable,
                 args.timeout,
                 args.quiet,
-                replace_requirements,
+                overrides,
             )
         )
 

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -75,8 +75,14 @@ def repository_name(repo_prefix, name, version, python_version):
 
 
 def whl_library(
-    name, extras, repo_name, pip_repo_name, python_interpreter, timeout, quiet,
-    replace_requirements
+    name,
+    extras,
+    repo_name,
+    pip_repo_name,
+    python_interpreter,
+    timeout,
+    quiet,
+    replace_requirements,
 ):
     """Generate whl_library snippets for a package and its extras.
 
@@ -170,13 +176,13 @@ def main():
         "--replace_requirement",
         action="append",
         default=[],
-        help="Specified to replace pip dependencies with bazel targets. Example: " +
-        "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
+        help="Specified to replace pip dependencies with bazel targets. Example: "
+        + "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
     )
     args = parser.parse_args()
 
     reqs = sorted(get_requirements(args.input), key=as_tuple)
-    replace_requirements = dict(rep.split('=') for rep in args.replace_requirement)
+    replace_requirements = dict(rep.split("=") for rep in args.replace_requirement)
     python_version = "%d%d" % (sys.version_info[0], sys.version_info[1])
     whl_targets = OrderedDict()
     whl_libraries = []

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -75,7 +75,8 @@ def repository_name(repo_prefix, name, version, python_version):
 
 
 def whl_library(
-    name, extras, repo_name, pip_repo_name, python_interpreter, timeout, quiet
+    name, extras, repo_name, pip_repo_name, python_interpreter, timeout, quiet,
+    replace_requirements
 ):
     """Generate whl_library snippets for a package and its extras.
 
@@ -87,6 +88,7 @@ def whl_library(
         python_interpreter:
         timeout: timeout for pip actions
         quiet: makes command run in quiet mode
+        replace_requirements: map from requirement to replacement label
     Returns:
       str: whl_library rule definition
     """
@@ -102,6 +104,7 @@ def whl_library(
         pip_args = pip_args,
         timeout = {timeout},
         quiet = {quiet},
+        replace_requirements = {replace_requirements},
     )""".format(
         name=name,
         repo_name=repo_name,
@@ -110,6 +113,7 @@ def whl_library(
         extras=",".join(['"%s"' % extra for extra in extras]),
         timeout=timeout,
         quiet=quiet,
+        replace_requirements=replace_requirements,
     )
 
 
@@ -162,9 +166,17 @@ def main():
         type=bool,
         required=True,
     )
+    parser.add_argument(
+        "--replace_requirement",
+        action="append",
+        default=[],
+        help="Specified to replace pip dependencies with bazel targets. Example: " +
+        "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
+    )
     args = parser.parse_args()
 
     reqs = sorted(get_requirements(args.input), key=as_tuple)
+    replace_requirements = dict(rep.split('=') for rep in args.replace_requirement)
     python_version = "%d%d" % (sys.version_info[0], sys.version_info[1])
     whl_targets = OrderedDict()
     whl_libraries = []
@@ -185,6 +197,7 @@ def main():
                 sys.executable,
                 args.timeout,
                 args.quiet,
+                replace_requirements,
             )
         )
 

--- a/src/whl.py
+++ b/src/whl.py
@@ -195,11 +195,11 @@ def main():
         help="The set of extras for which to generate library targets.",
     )
     parser.add_argument(
-        "--replace_requirement",
+        "--override",
         action="append",
         default=[],
         help="Specified to replace pip dependencies with bazel targets. Example: "
-        + "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
+        + "--override=protobuf=@com_google_protobuf//:protobuf_python",
     )
 
     args, pip_args = parser.parse_known_args()
@@ -228,10 +228,8 @@ py_library(
         extras_list.append(_get_numpy_headers(args.directory))
 
     extras = "\n".join(extras_list)
-    # --replace_requirement is in that order, replacement=requirement, but we
-    # want to flip this for the dict lookup to work, since we want to replace
-    # the requirement with the replacement, after all.
-    replacements = dict(reversed(rep.split("=")) for rep in args.replace_requirement)
+    # args.override looks like a list of requirement=replacement
+    replacements = dict(rep.split("=") for rep in args.override)
 
     result = """
 package(default_visibility = ["//visibility:public"])

--- a/src/whl.py
+++ b/src/whl.py
@@ -198,8 +198,8 @@ def main():
         "--replace_requirement",
         action="append",
         default=[],
-        help="Specified to replace pip dependencies with bazel targets. Example: " +
-        "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
+        help="Specified to replace pip dependencies with bazel targets. Example: "
+        + "--replace_requirement=protobuf=@com_google_protobuf//:protobuf_python",
     )
 
     args, pip_args = parser.parse_known_args()
@@ -231,7 +231,7 @@ py_library(
     # --replace_requirement is in that order, replacement=requirement, but we
     # want to flip this for the dict lookup to work, since we want to replace
     # the requirement with the replacement, after all.
-    replacements = dict(reversed(rep.split('=')) for rep in args.replace_requirement)
+    replacements = dict(reversed(rep.split("=")) for rep in args.replace_requirement)
 
     result = """
 package(default_visibility = ["//visibility:public"])
@@ -258,10 +258,14 @@ py_library(
 )
 {extras}""".format(
         requirements=args.requirements,
-        dependencies=",".join(['requirement("%s")' % d for d in dependencies(pkg)]),
-        dependencies=",\n        ".join([
-            '"%s"' % replacements[d] if d in replacements else 'requirement("%s")' % d
-            for d in dependencies(pkg)]),
+        dependencies=",\n        ".join(
+            [
+                '"%s"' % replacements[d]
+                if d in replacements
+                else 'requirement("%s")' % d
+                for d in dependencies(pkg)
+            ]
+        ),
         extras=extras,
     )
 


### PR DESCRIPTION
Certain packages require patches for their C++ extensions to work with bazel, or just in general for extra features. `rules_pip` can add a mechanism for applying patches and/or replacing BUILD files for dependencies, but I think it's best to allow users to use bazel's existing mechanisms and just defer to that.

Normally, users can just pull in a python package from pypi manually and use that, but if it's a dependency of another package, then `rules_pip` also pulls it in and risks multiple versions of the same dependency (or the same version but included from two paths).