### PR TITLE
Update whl_targets with overrides (follow up from#67)

### DIFF
--- a/src/piptool.py
+++ b/src/piptool.py
@@ -212,7 +212,7 @@ def main():
             )
         )
 
-    mappings=",\n  ".join(
+    mappings = ",\n  ".join(
         '"%s": "%s"' % (name, target) for name, target in whl_targets.items()
     )
 
@@ -253,7 +253,9 @@ def requirement(name, target=None):
 [alias(name=name, actual=pkg,  visibility=["//visibility:public"]) for name, pkg in {{
   {mappings}
 }}.items()]
-""".format(mappings=mappings)
+""".format(
+                mappings=mappings
+            )
         )
 
 

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -243,7 +243,7 @@ def requirement(name, target=None):
   return req
 """.format(
                 whl_libraries="\n".join(whl_libraries),
-                mappings={k.lower(): v for k, v in mappings.items()},
+                mappings=str({k.lower(): v for k, v in whl_targets.items()}),
             )
         )
 

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -192,25 +192,24 @@ def main():
         if req in overrides:
             # No whl_library is created, and no extras for overrides.
             whl_targets["%s" % name] = overrides[req]
-            continue
         else:
             whl_targets["%s" % name] = "@%s//:pkg" % repo_name
-        # For every extra that is possible from this requirements.txt
-        for extra in extras:
-            whl_targets["%s[%s]" % (name, extra)] = "@%s//:%s" % (repo_name, extra)
+            # For every extra that is possible from this requirements.txt
+            for extra in extras:
+                whl_targets["%s[%s]" % (name, extra)] = "@%s//:%s" % (repo_name, extra)
 
-        whl_libraries.append(
-            whl_library(
-                name,
-                extras,
-                repo_name,
-                args.name,
-                sys.executable,
-                args.timeout,
-                args.quiet,
-                overrides,
+            whl_libraries.append(
+                whl_library(
+                    name,
+                    extras,
+                    repo_name,
+                    args.name,
+                    sys.executable,
+                    args.timeout,
+                    args.quiet,
+                    overrides,
+                )
             )
-        )
 
     mappings = ",\n  ".join(
         '"%s": "%s"' % (name, target) for name, target in whl_targets.items()

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -243,7 +243,10 @@ def requirement(name, target=None):
   return req
 """.format(
                 whl_libraries="\n".join(whl_libraries),
-                mappings=str({k.lower(): v for k, v in whl_targets.items()}),
+                mappings=", ".join(
+                    '"%s": "%s"' % (name.lower(), target)
+                    for name, target in whl_targets.items()
+                ),
             )
         )
 

--- a/src/whl.py
+++ b/src/whl.py
@@ -229,7 +229,7 @@ py_library(
 
     extras = "\n".join(extras_list)
     # args.override looks like a list of requirement=replacement
-    replacements = dict(rep.split("=") for rep in args.override)
+    overrides = dict(rep.split("=") for rep in args.override)
 
     result = """
 package(default_visibility = ["//visibility:public"])
@@ -264,8 +264,8 @@ filegroup(
         requirements=args.requirements,
         dependencies=",\n        ".join(
             [
-                '"%s"' % replacements[d]
-                if d in replacements
+                '"%s"' % overrides[d]
+                if d in overrides
                 else 'requirement("%s")' % d
                 for d in dependencies(pkg)
             ]

--- a/src/whl.py
+++ b/src/whl.py
@@ -264,9 +264,7 @@ filegroup(
         requirements=args.requirements,
         dependencies=",\n        ".join(
             [
-                '"%s"' % overrides[d]
-                if d in overrides
-                else 'requirement("%s")' % d
+                '"%s"' % overrides[d] if d in overrides else 'requirement("%s")' % d
                 for d in dependencies(pkg)
             ]
         ),


### PR DESCRIPTION
This allows someone it still use `requirement("overridden-dep")`

Also, rename replacements to overrides in the code for better code search