### PR TITLE
Directly depend on C extensions via cc_import

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -56,6 +56,8 @@ def _pip_import_impl(repository_ctx):
 
     for label, pipdep in repository_ctx.attr.overrides.items():
         args += ["--override=%s=%s" % (label, pipdep)]
+    if repository_ctx.attr.cc_import:
+        args += ["--cc_import"]
 
     result = _execute(repository_ctx, args, quiet = repository_ctx.attr.quiet)
     if result.return_code:
@@ -96,6 +98,7 @@ pip_import(
 This replaces "protobuf" with the bazel version even for indirect dependencies on it.
 """),
         "timeout": attr.int(default = 1200, doc = "Timeout for pip actions"),
+        "cc_import": attr.bool(doc = "Enable cc_import() for shared libraries."),
         "_script": attr.label(
             executable = True,
             default = Label("@com_github_ali5h_rules_pip//src:piptool.py"),
@@ -148,6 +151,8 @@ def _whl_impl(repository_ctx):
         ]
     for label, pipdep in repository_ctx.attr.overrides.items():
         args += ["--override=%s=%s" % (label, pipdep)]
+    if repository_ctx.attr.cc_import:
+        args += ["--cc_import"]
 
     args += pip_args
 
@@ -171,6 +176,7 @@ If the label is specified it will overwrite the python_interpreter attribute.
         "pip_args": attr.string_list(default = []),
         "timeout": attr.int(default = 1200, doc = "Timeout for pip actions"),
         "overrides": attr.label_keyed_string_dict(),
+        "cc_import": attr.bool(),
         "_script": attr.label(
             executable = True,
             default = Label("@com_github_ali5h_rules_pip//src:whl.py"),

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -78,6 +78,7 @@ pip_import(
     },
     python_interpreter = "python3.8",
     requirements = "//tests:requirements.txt",
+    cc_import = True,
 )
 
 load(

--- a/internal.bzl
+++ b/internal.bzl
@@ -1,0 +1,26 @@
+
+def _expose_cc_import_as_runfiles_impl(ctx):
+    cc_info = ctx.attr.src[CcInfo]
+
+    runfiles = []
+    
+    for linker_input in cc_info.linking_context.linker_inputs.to_list():
+        for library in linker_input.libraries:
+            if library.dynamic_library:
+                runfiles.append(library.dynamic_library)
+            if library.resolved_symlink_dynamic_library:
+                runfiles.append(library.resolved_symlink_dynamic_library)
+
+    # print(runfiles)
+    return [
+        cc_info,
+        DefaultInfo(runfiles = ctx.runfiles(files = runfiles)),
+    ]
+
+
+expose_cc_import_as_runfiles = rule(
+    attrs = {
+        "src": attr.label(mandatory = True, providers = [CcInfo]),
+    },
+    implementation = _expose_cc_import_as_runfiles_impl,
+)

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -85,6 +85,7 @@ def whl_library(
     timeout,
     quiet,
     req_to_overrides,
+    cc_import,
 ):
     """Generate whl_library snippets for a package and its extras.
 
@@ -97,6 +98,7 @@ def whl_library(
         timeout: timeout for pip actions
         quiet: makes command run in quiet mode
         req_to_overrides: map from requirement to replacement label
+        cc_import: use cc_import() or not
     Returns:
       str: whl_library rule definition
     """
@@ -113,6 +115,7 @@ def whl_library(
         timeout = {timeout},
         quiet = {quiet},
         overrides = {overrides},
+        cc_import = {cc_import},
     )""".format(
         name=name,
         repo_name=repo_name,
@@ -122,6 +125,7 @@ def whl_library(
         timeout=timeout,
         quiet=quiet,
         overrides={label: req for req, label in req_to_overrides.items()},
+        cc_import=cc_import,
     )
 
 
@@ -181,6 +185,11 @@ def main():
         help="Specified to replace pip dependencies with bazel targets. Example: "
         + "--override=@com_google_protobuf//:protobuf_python=protobuf",
     )
+    parser.add_argument(
+        "--cc_import",
+        action="store_true",
+        help="Use cc_import() for non-C-extension binaries",
+    )
     args = parser.parse_args()
 
     reqs = sorted(get_requirements(args.input), key=as_tuple)
@@ -211,6 +220,7 @@ def main():
                     args.timeout,
                     args.quiet,
                     req_to_overrides,
+                    args.cc_import,
                 )
             )
 

--- a/src/whl.py
+++ b/src/whl.py
@@ -316,6 +316,8 @@ py_library(
         "BUILD",
         "WORKSPACE",
         "__pycache__",
+        "**/*.so",
+        "**/*.dll",
     ]),
     # This makes this directory a top-level in the python import
     # search path for anything that depends on this.

--- a/src/whl.py
+++ b/src/whl.py
@@ -242,7 +242,7 @@ def main():
     pkg = install_package(args.package, args.directory, pip_args)
 
     extensions = _parse_extensions(pkg.filename)
-    cc_import_names = [name.replace("/", "__") for name in extensions]
+    cc_import_names = [name.replace("/", "__").replace(".", "_") for name in extensions]
     cc_imports = [
         """
 cc_import(


### PR DESCRIPTION
Adds `cc_import()` rules for `.so` and `.dll` files, so bazel moves them into the `_so_lib/` folder with everything else